### PR TITLE
Fix for handling of JsonElement data during serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.3] - 2022-04-11
+
+### Changed
+
+- Fixes handling of JsonElement types in additionData during serialization
+
 ## [1.0.0-preview.2] - 2022-04-04
 
 ### Changed

--- a/src/JsonSerializationWriter.cs
+++ b/src/JsonSerializationWriter.cs
@@ -399,6 +399,10 @@ namespace Microsoft.Kiota.Serialization.Json
                 case Time time:
                     WriteTimeValue(key, time);
                     break;
+                case JsonElement jsonElement:
+                    if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
+                    jsonElement.WriteTo(writer);
+                    break;
                 case object o:
                     WriteNonParsableObjectValue(key, o);
                     break;

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.2</VersionSuffix>
+    <VersionSuffix>preview.3</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -23,7 +23,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-        - Breaking: simplifies the field deserializers.
+        - Fixes handling of JsonElement types in additionalData during serialization.
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/426

Essentially, due to the way the deserialization works here, it is possible to have instances of `JsonElement` in the additionalData.

https://github.com/microsoft/kiota-serialization-json-dotnet/blob/528e54b2321097beff8458fca0eee404979ba0ac/src/JsonParseNode.cs#L350

This therefore means, the SerializationWriter which depends on reflection of properties would also need to support this scenario as JsonElement would yield an exception when trying to look up its properties via reflection.