### PR TITLE
Changes target runtime to netstandard2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.4] - 2022-04-12
+
+### Changed
+
+- Breaking: Changes target runtime to netstandard2.0
+
 ## [1.0.0-preview.3] - 2022-04-11
 
 ### Changed

--- a/src/JsonParseNode.cs
+++ b/src/JsonParseNode.cs
@@ -11,6 +11,7 @@ using System.Text.Json;
 using Microsoft.Kiota.Abstractions.Serialization;
 using Microsoft.Kiota.Abstractions;
 using System.Xml;
+using Microsoft.Kiota.Abstractions.Extensions;
 
 namespace Microsoft.Kiota.Serialization.Json
 {

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota JSON Serialization Library for dotnet using System.Text.Json</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-serialization-json-dotnet</RepositoryUrl>
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.3</VersionSuffix>
+    <VersionSuffix>preview.4</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -23,7 +23,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-        - Fixes handling of JsonElement types in additionalData during serialization.
+        - [Breaking] Change target runtime to netstandard 2.0
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.4" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-preview.5" />
     <PackageReference Include="System.Text.Json" Version="6.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
This is part of https://github.com/microsoft/kiota-abstractions-dotnet/issues/12

Depends on https://github.com/microsoft/kiota-abstractions-dotnet/pull/14