### PR TITLE
Fixes bug where JsonParseNode.GetChildNode would throw an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-preview.6] - 2022-05-27
+
+### Changed
+
+- Fixes a bug where JsonParseNode.GetChildNode would throw an exception if the property name did not exist in the json.
+
 ## [1.0.0-preview.5] - 2022-05-18
 
 ### Changed

--- a/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -85,5 +85,17 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             Assert.NotEmpty(phonesList);
             Assert.Equal("+1 412 555 0109", phonesList[0]);
         }
+
+        [Fact]
+        public void ReturnsDefaultIfChildNodeDoesNotExist()
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(TestUserJson);
+            var rootParseNode = new JsonParseNode(jsonDocument.RootElement);
+            // Try to get an imaginary node value
+            var imaginaryNode = rootParseNode.GetChildNode("imaginaryNode");
+            // Assert
+            Assert.Null(imaginaryNode);
+        }
     }
 }

--- a/src/JsonParseNode.cs
+++ b/src/JsonParseNode.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
@@ -94,7 +94,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the <see cref="DateTimeOffset"/> value from the json node
         /// </summary>
         /// <returns>A <see cref="DateTimeOffset"/> value</returns>
-        public DateTimeOffset? GetDateTimeOffsetValue() 
+        public DateTimeOffset? GetDateTimeOffsetValue()
         {
             // JsonElement.GetDateTimeOffset is super strict so try to be more lenient if it fails(e.g. when we have whitespace or other variant formats).
             // ref - https://docs.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support
@@ -366,10 +366,18 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="identifier">The identifier of the child node</param>
         /// <returns>An instance of <see cref="IParseNode"/></returns>
-        public IParseNode GetChildNode(string identifier) => new JsonParseNode(_jsonNode.GetProperty(identifier ?? throw new ArgumentNullException(nameof(identifier))))
+        public IParseNode GetChildNode(string identifier)
         {
-            OnBeforeAssignFieldValues = OnBeforeAssignFieldValues,
-            OnAfterAssignFieldValues = OnAfterAssignFieldValues
-        };
+            if(_jsonNode.TryGetProperty(identifier ?? throw new ArgumentNullException(nameof(identifier)), out var jsonElement)) 
+            {
+                return new JsonParseNode(jsonElement)
+                {
+                    OnBeforeAssignFieldValues = OnBeforeAssignFieldValues,
+                    OnAfterAssignFieldValues = OnAfterAssignFieldValues
+                };
+            }
+
+            return default;
+        }
     }
 }

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -14,7 +14,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.5</VersionSuffix>
+    <VersionSuffix>preview.6</VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Enable this line once we go live to prevent breaking changes -->
@@ -23,7 +23,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-        - Updated abstractions version to 1.0.0.preview8
+        - Fixes bug where JsonParseNode.GetChildNode would throw an exception if the property name did not exist in the json.
     </PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/461

It updates the implementation of `JsonParseNode.GetChildNode` to return `default` as opposed to throwing `KeyNotFoundException` to allow the expected flow of the code generated (example below) by Kiota in the event the node does not exist. 

```cs
  _ = parseNode ?? throw new ArgumentNullException(nameof(parseNode));
  var mappingValueNode = parseNode.GetChildNode("@odata.type");
  var mappingValue = mappingValueNode?.GetStringValue();
  return mappingValue switch {
      "#microsoft.graph.managedDevice" => new ManagedDevice(),
      _ => new ManagedDevice(),
  };
```