### PR TITLE
Adds support for nullable reference types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.0-rc.2] - 2023-01-17
+
+### Changed
+
+- Adds support for nullable reference types
+
 ## [1.0.0-rc.1] - 2022-12-15
 
 ### Changed

--- a/src/JsonParseNode.cs
+++ b/src/JsonParseNode.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the string value from the json node
         /// </summary>
         /// <returns>A string value</returns>
-        public string GetStringValue() => _jsonNode.ValueKind == JsonValueKind.String ? _jsonNode.GetString() : null;
+        public string? GetStringValue() => _jsonNode.ValueKind == JsonValueKind.String ? _jsonNode.GetString() : null;
 
         /// <summary>
         /// Get the boolean value from the json node
@@ -99,7 +99,7 @@ namespace Microsoft.Kiota.Serialization.Json
             // JsonElement.GetDateTimeOffset is super strict so try to be more lenient if it fails(e.g. when we have whitespace or other variant formats).
             // ref - https://docs.microsoft.com/en-us/dotnet/standard/datetime/system-text-json-support
             if(!_jsonNode.TryGetDateTimeOffset(out var value))
-                value = DateTimeOffset.Parse(_jsonNode.GetString());
+                value = DateTimeOffset.Parse(_jsonNode.GetString()!);
 
             return value;
         }
@@ -154,11 +154,11 @@ namespace Microsoft.Kiota.Serialization.Json
             if(string.IsNullOrEmpty(rawValue)) return null;
             if(typeof(T).GetCustomAttributes<FlagsAttribute>().Any())
             {
-                return (T)(object)rawValue
+                return (T)(object)rawValue!
                     .Split(',')
                     .Select(x => Enum.TryParse<T>(x, true, out var result) ? result : (T?)null)
                     .Where(x => !x.Equals(null))
-                    .Select(x => (int)(object)x)
+                    .Select(x => (int)(object)x!)
                     .Sum();
             }
             else
@@ -208,23 +208,23 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Gets the byte array value of the node.
         /// </summary>
         /// <returns>The byte array value of the node.</returns>
-        public byte[] GetByteArrayValue() {
+        public byte[]? GetByteArrayValue() {
             var rawValue = _jsonNode.GetString();
             if(string.IsNullOrEmpty(rawValue)) return null;
             return Convert.FromBase64String(rawValue);
         }
-        private static Type booleanType = typeof(bool?);
-        private static Type byteType = typeof(byte?);
-        private static Type sbyteType = typeof(sbyte?);
-        private static Type stringType = typeof(string);
-        private static Type intType = typeof(int?);
-        private static Type floatType = typeof(float?);
-        private static Type doubleType = typeof(double?);
-        private static Type guidType = typeof(Guid?);
-        private static Type dateTimeOffsetType = typeof(DateTimeOffset?);
-        private static Type timeSpanType = typeof(TimeSpan?);
-        private static Type dateType = typeof(Date?);
-        private static Type timeType = typeof(Time?);
+        private static readonly Type booleanType = typeof(bool?);
+        private static readonly Type byteType = typeof(byte?);
+        private static readonly Type sbyteType = typeof(sbyte?);
+        private static readonly Type stringType = typeof(string);
+        private static readonly Type intType = typeof(int?);
+        private static readonly Type floatType = typeof(float?);
+        private static readonly Type doubleType = typeof(double?);
+        private static readonly Type guidType = typeof(Guid?);
+        private static readonly Type dateTimeOffsetType = typeof(DateTimeOffset?);
+        private static readonly Type timeSpanType = typeof(TimeSpan?);
+        private static readonly Type dateType = typeof(Date?);
+        private static readonly Type timeType = typeof(Time?);
 
         /// <summary>
         /// Get the collection of primitives of type <typeparam name="T"/>from the json node
@@ -242,29 +242,29 @@ namespace Microsoft.Kiota.Serialization.Json
                         OnAfterAssignFieldValues = OnAfterAssignFieldValues
                     };
                     if(genericType == booleanType)
-                        yield return (T)(object)currentParseNode.GetBoolValue();
+                        yield return (T)(object)currentParseNode.GetBoolValue()!;
                     else if(genericType == byteType)
-                        yield return (T)(object)currentParseNode.GetByteValue();
+                        yield return (T)(object)currentParseNode.GetByteValue()!;
                     else if(genericType == sbyteType)
-                        yield return (T)(object)currentParseNode.GetSbyteValue();
+                        yield return (T)(object)currentParseNode.GetSbyteValue()!;
                     else if(genericType == stringType)
-                        yield return (T)(object)currentParseNode.GetStringValue();
+                        yield return (T)(object)currentParseNode.GetStringValue()!;
                     else if(genericType == intType)
-                        yield return (T)(object)currentParseNode.GetIntValue();
+                        yield return (T)(object)currentParseNode.GetIntValue()!;
                     else if(genericType == floatType)
-                        yield return (T)(object)currentParseNode.GetFloatValue();
+                        yield return (T)(object)currentParseNode.GetFloatValue()!;
                     else if(genericType == doubleType)
-                        yield return (T)(object)currentParseNode.GetDoubleValue();
+                        yield return (T)(object)currentParseNode.GetDoubleValue()!;
                     else if(genericType == guidType)
-                        yield return (T)(object)currentParseNode.GetGuidValue();
+                        yield return (T)(object)currentParseNode.GetGuidValue()!;
                     else if(genericType == dateTimeOffsetType)
-                        yield return (T)(object)currentParseNode.GetDateTimeOffsetValue();
+                        yield return (T)(object)currentParseNode.GetDateTimeOffsetValue()!;
                     else if(genericType == timeSpanType)
-                        yield return (T)(object)currentParseNode.GetTimeSpanValue();
+                        yield return (T)(object)currentParseNode.GetTimeSpanValue()!;
                     else if(genericType == dateType)
-                        yield return (T)(object)currentParseNode.GetDateValue();
+                        yield return (T)(object)currentParseNode.GetDateValue()!;
                     else if(genericType == timeType)
-                        yield return (T)(object)currentParseNode.GetTimeValue();
+                        yield return (T)(object)currentParseNode.GetTimeValue()!;
                     else
                         throw new InvalidOperationException($"unknown type for deserialization {genericType.FullName}");
                 }
@@ -274,12 +274,12 @@ namespace Microsoft.Kiota.Serialization.Json
         /// <summary>
         /// The action to perform before assigning field values.
         /// </summary>
-        public Action<IParsable> OnBeforeAssignFieldValues { get; set; }
+        public Action<IParsable>? OnBeforeAssignFieldValues { get; set; }
 
         /// <summary>
         /// The action to perform after assigning field values.
         /// </summary>
-        public Action<IParsable> OnAfterAssignFieldValues { get; set; }
+        public Action<IParsable>? OnAfterAssignFieldValues { get; set; }
 
         /// <summary>
         /// Get the object of type <typeparam name="T"/>from the json node
@@ -297,11 +297,10 @@ namespace Microsoft.Kiota.Serialization.Json
         private void AssignFieldValues<T>(T item) where T : IParsable
         {
             if(_jsonNode.ValueKind != JsonValueKind.Object) return;
-            IDictionary<string, object> itemAdditionalData = null;
+            IDictionary<string, object>? itemAdditionalData = null;
             if(item is IAdditionalDataHolder holder)
             {
-                if(holder.AdditionalData == null)
-                    holder.AdditionalData = new Dictionary<string, object>();
+                holder.AdditionalData ??= new Dictionary<string, object>();
                 itemAdditionalData = holder.AdditionalData;
             }
             var fieldDeserializers = item.GetFieldDeserializers();
@@ -324,7 +323,7 @@ namespace Microsoft.Kiota.Serialization.Json
                 else if (itemAdditionalData != null)
                 {
                     Debug.WriteLine($"found additional property {fieldValue.Name} to deserialize");
-                    itemAdditionalData.TryAdd(fieldValue.Name, TryGetAnything(fieldValue.Value));
+                    IDictionaryExtensions.TryAdd(itemAdditionalData, fieldValue.Name, TryGetAnything(fieldValue.Value)!);
                 }
                 else
                 {
@@ -332,7 +331,7 @@ namespace Microsoft.Kiota.Serialization.Json
                 }
             }
         }
-        private object TryGetAnything(JsonElement element)
+        private static object? TryGetAnything(JsonElement element)
         {
             switch(element.ValueKind)
             {
@@ -372,7 +371,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="identifier">The identifier of the child node</param>
         /// <returns>An instance of <see cref="IParseNode"/></returns>
-        public IParseNode GetChildNode(string identifier)
+        public IParseNode? GetChildNode(string identifier)
         {
             if(_jsonNode.ValueKind == JsonValueKind.Object && _jsonNode.TryGetProperty(identifier ?? throw new ArgumentNullException(nameof(identifier)), out var jsonElement)) 
             {

--- a/src/JsonSerializationWriter.cs
+++ b/src/JsonSerializationWriter.cs
@@ -38,17 +38,17 @@ namespace Microsoft.Kiota.Serialization.Json
         /// <summary>
         /// The action to perform before object serialization
         /// </summary>
-        public Action<IParsable> OnBeforeObjectSerialization { get; set; }
+        public Action<IParsable>? OnBeforeObjectSerialization { get; set; }
 
         /// <summary>
         /// The action to perform after object serialization
         /// </summary>
-        public Action<IParsable> OnAfterObjectSerialization { get; set; }
+        public Action<IParsable>? OnAfterObjectSerialization { get; set; }
 
         /// <summary>
         /// The action to perform on the start of object serialization
         /// </summary>
-        public Action<IParsable, ISerializationWriter> OnStartObjectSerialization { get; set; }
+        public Action<IParsable, ISerializationWriter>? OnStartObjectSerialization { get; set; }
 
         /// <summary>
         /// Get the stream of the serialized content
@@ -65,11 +65,11 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The string value</param>
-        public void WriteStringValue(string key, string value)
+        public void WriteStringValue(string? key, string? value)
         {
             if(value != null)
             { // we want to keep empty string because they are meaningful
-                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
+                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key!);
                 writer.WriteStringValue(value);
             }
         }
@@ -79,9 +79,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The boolean value</param>
-        public void WriteBoolValue(string key, bool? value)
+        public void WriteBoolValue(string? key, bool? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteBooleanValue(value.Value);
         }
 
@@ -90,9 +90,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The byte value</param>
-        public void WriteByteValue(string key, byte? value)
+        public void WriteByteValue(string? key, byte? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteNumberValue(Convert.ToInt32(value.Value));
         }
 
@@ -101,9 +101,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The sbyte value</param>
-        public void WriteSbyteValue(string key, sbyte? value)
+        public void WriteSbyteValue(string? key, sbyte? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteNumberValue(Convert.ToInt32(value.Value));
         }
 
@@ -112,9 +112,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The int value</param>
-        public void WriteIntValue(string key, int? value)
+        public void WriteIntValue(string? key, int? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteNumberValue(value.Value);
         }
 
@@ -123,9 +123,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The float value</param>
-        public void WriteFloatValue(string key, float? value)
+        public void WriteFloatValue(string? key, float? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteNumberValue(value.Value);
         }
 
@@ -134,9 +134,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The long value</param>
-        public void WriteLongValue(string key, long? value)
+        public void WriteLongValue(string? key, long? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteNumberValue(value.Value);
         }
 
@@ -145,9 +145,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The double value</param>
-        public void WriteDoubleValue(string key, double? value)
+        public void WriteDoubleValue(string? key, double? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteNumberValue(value.Value);
         }
 
@@ -156,9 +156,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The decimal value</param>
-        public void WriteDecimalValue(string key, decimal? value)
+        public void WriteDecimalValue(string? key, decimal? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteNumberValue(value.Value);
         }
 
@@ -167,9 +167,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The Guid value</param>
-        public void WriteGuidValue(string key, Guid? value)
+        public void WriteGuidValue(string? key, Guid? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteStringValue(value.Value);
         }
 
@@ -178,9 +178,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The DateTimeOffset value</param>
-        public void WriteDateTimeOffsetValue(string key, DateTimeOffset? value)
+        public void WriteDateTimeOffsetValue(string? key, DateTimeOffset? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteStringValue(value.Value);
         }
 
@@ -189,9 +189,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The TimeSpan value</param>
-        public void WriteTimeSpanValue(string key, TimeSpan? value)
+        public void WriteTimeSpanValue(string? key, TimeSpan? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteStringValue(XmlConvert.ToString(value.Value));
         }
 
@@ -200,9 +200,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The Date value</param>
-        public void WriteDateValue(string key, Date? value)
+        public void WriteDateValue(string? key, Date? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteStringValue(value.Value.ToString());
         }
 
@@ -211,9 +211,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The Time value</param>
-        public void WriteTimeValue(string key, Time? value)
+        public void WriteTimeValue(string? key, Time? value)
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue) writer.WriteStringValue(value.Value.ToString());
         }
 
@@ -221,9 +221,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Write the null value
         /// </summary>
         /// <param name="key">The key of the json node</param>
-        public void WriteNullValue(string key)
+        public void WriteNullValue(string? key)
         {
-            if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key!);
             writer.WriteNullValue();
         }
 
@@ -232,9 +232,9 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The enumeration value</param>
-        public void WriteEnumValue<T>(string key, T? value) where T : struct, Enum
+        public void WriteEnumValue<T>(string? key, T? value) where T : struct, Enum
         {
-            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key);
+            if(!string.IsNullOrEmpty(key) && value.HasValue) writer.WritePropertyName(key!);
             if(value.HasValue)
             {
                 if(typeof(T).GetCustomAttributes<FlagsAttribute>().Any())
@@ -253,11 +253,11 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="values">The primitive collection</param>
-        public void WriteCollectionOfPrimitiveValues<T>(string key, IEnumerable<T> values)
+        public void WriteCollectionOfPrimitiveValues<T>(string? key, IEnumerable<T>? values)
         {
             if(values != null)
             { //empty array is meaningful
-                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
+                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key!);
                 writer.WriteStartArray();
                 foreach(var collectionValue in values)
                     WriteAnyValue(null, collectionValue);
@@ -270,11 +270,11 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key of the json node</param>
         /// <param name="values">The object collection</param>
-        public void WriteCollectionOfObjectValues<T>(string key, IEnumerable<T> values) where T : IParsable
+        public void WriteCollectionOfObjectValues<T>(string? key, IEnumerable<T>? values) where T : IParsable
         {
             if(values != null)
             { //empty array is meaningful
-                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
+                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key!);
                 writer.WriteStartArray();
                 foreach(var item in values)
                     WriteObjectValue<T>(null, item);
@@ -286,11 +286,11 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="values">The enum values to be written.</param>
-        public void WriteCollectionOfEnumValues<T>(string key, IEnumerable<T?> values) where T : struct, Enum
+        public void WriteCollectionOfEnumValues<T>(string? key, IEnumerable<T?>? values) where T : struct, Enum
         {
             if(values != null)
             { //empty array is meaningful
-                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
+                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key!);
                 writer.WriteStartArray();
                 foreach(var item in values)
                     WriteEnumValue<T>(null, item);
@@ -302,7 +302,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="key">The key to be used for the written value. May be null.</param>
         /// <param name="value">The byte array to be written.</param>
-        public void WriteByteArrayValue(string key, byte[] value)
+        public void WriteByteArrayValue(string? key, byte[]? value)
         {
             if(value != null)//empty array is meaningful
                 WriteStringValue(key, value.Any() ? Convert.ToBase64String(value) : string.Empty);
@@ -314,11 +314,11 @@ namespace Microsoft.Kiota.Serialization.Json
         /// <param name="key">The key of the json node</param>
         /// <param name="value">The object instance to write</param>
         /// <param name="additionalValuesToMerge">The additional values to merge to the main value when serializing an intersection wrapper.</param>
-        public void WriteObjectValue<T>(string key, T value, params IParsable[] additionalValuesToMerge) where T : IParsable
+        public void WriteObjectValue<T>(string? key, T? value, params IParsable[] additionalValuesToMerge) where T : IParsable
         {
             if(value != null || additionalValuesToMerge.Any(static x => x != null))
             {
-                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
+                if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key!);
                 if(value != null) OnBeforeObjectSerialization?.Invoke(value);
                 writer.WriteStartObject();
                 if(value != null) {
@@ -349,10 +349,10 @@ namespace Microsoft.Kiota.Serialization.Json
                 WriteAnyValue(dataValue.Key, dataValue.Value);
         }
 
-        private void WriteNonParsableObjectValue<T>(string key, T value)
+        private void WriteNonParsableObjectValue<T>(string? key, T value)
         {
             if(!string.IsNullOrEmpty(key))
-                writer.WritePropertyName(key);
+                writer.WritePropertyName(key!);
             writer.WriteStartObject();
             if(value == null) writer.WriteNullValue();
             else
@@ -360,7 +360,7 @@ namespace Microsoft.Kiota.Serialization.Json
                     WriteAnyValue(oProp.Name, oProp.GetValue(value));
             writer.WriteEndObject();
         }
-        private void WriteAnyValue<T>(string key, T value)
+        private void WriteAnyValue<T>(string? key, T value)
         {
             switch(value)
             {
@@ -410,7 +410,7 @@ namespace Microsoft.Kiota.Serialization.Json
                     WriteTimeValue(key, time);
                     break;
                 case JsonElement jsonElement:
-                    if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key);
+                    if(!string.IsNullOrEmpty(key)) writer.WritePropertyName(key!);
                     jsonElement.WriteTo(writer);
                     break;
                 case object o:

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
 
   <PropertyGroup>
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota JSON Serialization Library for dotnet using System.Text.Json</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-serialization-json-dotnet</RepositoryUrl>

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -6,7 +6,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Kiota JSON Serialization Library for dotnet using System.Text.Json</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/microsoft/kiota-serialization-json-dotnet</RepositoryUrl>
@@ -23,8 +23,11 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <PackageReleaseNotes>
-        - Release candidate 1.
+        https://github.com/microsoft/kiota-serialization-json-dotnet/releases
     </PackageReleaseNotes>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
@@ -32,7 +35,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.3" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.0.0-rc.4" />
     <PackageReference Include="System.Text.Json" Version="7.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR is part of https://github.com/microsoft/kiota/issues/2073

Changes include: -

- Adds nullable markers to APIs that can return null. 
- Adds nullable feature in project as well as net6.0 target to allow for proper feature functionality. Also sets `TreatWarningsAsErrors` to alleviate any potential mistakes being ignored.