### PR TITLE
Fixes serialization of DateTime type in additionalData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [1.0.3] - 2023-03-15
+
+### Changed
+
+- Fixes serialization of DateTime type in the additionalData
+
 ## [1.0.2] - 2023-03-10
 
 ### Changed

--- a/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
+++ b/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
                     {"jobTitle","Author"}, // write string value
                     {"createdDateTime", DateTimeOffset.MinValue}, // write date value
                     {"businessPhones", new List<string>() {"+1 412 555 0109"}}, // write collection of primitives value
+                    {"endDateTime", new DateTime(2023,03,14) }, // ensure the DateTime doesn't crash
                     {"manager", new TestEntity{Id = "48d31887-5fad-4d73-a9f5-3c356e68a038"}}, // write nested object value
                 }
             };
@@ -50,7 +51,8 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
                                  "\"jobTitle\":\"Author\"," +
                                  "\"createdDateTime\":\"0001-01-01T00:00:00+00:00\"," +
                                  "\"businessPhones\":[\"\\u002B1 412 555 0109\"]," +
-                                 "\"manager\":{\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"}"+
+                                 "\"endDateTime\":\"2023-03-14T00:00:00+03:00\"," +
+                                 "\"manager\":{\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"}" +
                                  "}";
             Assert.Equal(expectedString, serializedJsonString);
         }

--- a/src/JsonSerializationWriter.cs
+++ b/src/JsonSerializationWriter.cs
@@ -406,6 +406,9 @@ namespace Microsoft.Kiota.Serialization.Json
                 case Date date:
                     WriteDateValue(key, date);
                     break;
+                case DateTime dateTime:
+                    WriteDateTimeOffsetValue(key, new DateTimeOffset(dateTime));
+                    break;
                 case Time time:
                     WriteTimeValue(key, time);
                     break;

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.3</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Fixes the serialization of DateTime type when added to the additionalData.

By default, this will be handled as a `DateTimeOffset` type as the Date type exists in the abstraction library for less specificity.


Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1722