### PR TITLE
Fixes enum handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.5] - 2023-04-04
+
+### Changed
+
+- Fixes a bug where EnumMember attribute enums would have the first letter lowecased
+
 ## [1.0.4] - 2023-04-03
 
 ### Changed

--- a/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
+++ b/Microsoft.Kiota.Serialization.Json.Tests/JsonSerializationWriterTests.cs
@@ -137,13 +137,61 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             var expectedString = "[{" +
                                  "\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"," +
                                  "\"numbers\":\"one,two\"," +
-                                 "\"testNamingEnum\":\"item2:SubItem1\"," +
+                                 "\"testNamingEnum\":\"Item2:SubItem1\"," +
                                  "\"mobilePhone\":null," +
                                  "\"accountEnabled\":false," +
                                  "\"jobTitle\":\"Author\"," +
                                  "\"createdDateTime\":\"0001-01-01T00:00:00+00:00\"," +
                                  "\"businessPhones\":[\"\\u002B1 412 555 0109\"]," +
                                  "\"manager\":{\"id\":\"48d31887-5fad-4d73-a9f5-3c356e68a038\"}" +
+                                 "}]";
+            Assert.Equal(expectedString, serializedJsonString);
+        }
+
+        [Fact]
+        public void WritesEnumValuesAsCamelCasedIfNotEscaped()
+        {
+            // Arrange
+            var testEntity = new TestEntity()
+            {
+                TestNamingEnum = TestNamingEnum.Item1,
+            };
+            var entityList = new List<TestEntity>() { testEntity };
+            using var jsonSerializerWriter = new JsonSerializationWriter();
+            // Act
+            jsonSerializerWriter.WriteCollectionOfObjectValues(string.Empty, entityList);
+            // Get the json string from the stream.
+            var serializedStream = jsonSerializerWriter.GetSerializedContent();
+            using var reader = new StreamReader(serializedStream, Encoding.UTF8);
+            var serializedJsonString = reader.ReadToEnd();
+
+            // Assert
+            var expectedString = "[{" +
+                                 "\"testNamingEnum\":\"item1\"" + // Camel Cased
+                                 "}]";
+            Assert.Equal(expectedString, serializedJsonString);
+        }
+
+        [Fact]
+        public void WritesEnumValuesAsDescribedIfEscaped()
+        {
+            // Arrange
+            var testEntity = new TestEntity()
+            {
+                TestNamingEnum = TestNamingEnum.Item2SubItem1,
+            };
+            var entityList = new List<TestEntity>() { testEntity };
+            using var jsonSerializerWriter = new JsonSerializationWriter();
+            // Act
+            jsonSerializerWriter.WriteCollectionOfObjectValues(string.Empty, entityList);
+            // Get the json string from the stream.
+            var serializedStream = jsonSerializerWriter.GetSerializedContent();
+            using var reader = new StreamReader(serializedStream, Encoding.UTF8);
+            var serializedJsonString = reader.ReadToEnd();
+
+            // Assert
+            var expectedString = "[{" +
+                                 "\"testNamingEnum\":\"Item2:SubItem1\"" + // Appears same as attribute
                                  "}]";
             Assert.Equal(expectedString, serializedJsonString);
         }

--- a/src/JsonSerializationWriter.cs
+++ b/src/JsonSerializationWriter.cs
@@ -444,7 +444,7 @@ namespace Microsoft.Kiota.Serialization.Json
             if (type.GetMember(name).FirstOrDefault()?.GetCustomAttribute<EnumMemberAttribute>() is { } attribute)
                 return attribute.Value;
             
-            return name?.ToFirstCharacterLowerCase();
+            return name.ToFirstCharacterLowerCase();
         }
     }
 }

--- a/src/JsonSerializationWriter.cs
+++ b/src/JsonSerializationWriter.cs
@@ -243,9 +243,8 @@ namespace Microsoft.Kiota.Serialization.Json
                                             .Cast<T>()
                                             .Where(x => value.Value.HasFlag(x))
                                             .Select(GetEnumName)
-                                            .Select(x => x.ToFirstCharacterLowerCase())
                                             .Aggregate((x, y) => $"{x},{y}"));
-                else writer.WriteStringValue(GetEnumName(value.Value).ToFirstCharacterLowerCase());
+                else writer.WriteStringValue(GetEnumName(value.Value));
             }
         }
 
@@ -435,7 +434,7 @@ namespace Microsoft.Kiota.Serialization.Json
             GC.SuppressFinalize(this);
         }
         
-        private string GetEnumName<T>(T value) where T : struct, Enum
+        private string? GetEnumName<T>(T value) where T : struct, Enum
         {
             var type = typeof(T);
 
@@ -445,7 +444,7 @@ namespace Microsoft.Kiota.Serialization.Json
             if (type.GetMember(name).FirstOrDefault()?.GetCustomAttribute<EnumMemberAttribute>() is { } attribute)
                 return attribute.Value;
             
-            return name;
+            return name?.ToFirstCharacterLowerCase();
         }
     }
 }

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.4</VersionPrefix>
+    <VersionPrefix>1.0.5</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Closes https://github.com/microsoft/kiota-serialization-json-dotnet/issues/78

Eliminates the default lowercasing of first character in enum options in scenario where the `EnumMember` is declared. 

Tests added to validate this.