### PR TITLE
Fix inheritance new keyword for hiding existing implementation of deserializing method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.5] - 2023-05-17
+
+###Changed
+
+-Fixes a bug where 'new' keyword on derived classes from IParsable is not being respected, returning null properties for json parsed nodes
+
+### Added
+
 ## [1.0.5] - 2023-04-04
 
 ### Changed

--- a/src/JsonParseNode.cs
+++ b/src/JsonParseNode.cs
@@ -307,7 +307,9 @@ namespace Microsoft.Kiota.Serialization.Json
                 holder.AdditionalData ??= new Dictionary<string, object>();
                 itemAdditionalData = holder.AdditionalData;
             }
-            var fieldDeserializers = item.GetFieldDeserializers();
+            //When targeting maccatalyst, new keyword for hiding an existing member is not being respected, returning only id and odata type
+            //the below line fixes the issue
+            var fieldDeserializers = (IDictionary<string, Action<IParseNode>>) item.GetType().GetMethod("GetFieldDeserializers").Invoke(item, null);  
 
             foreach(var fieldValue in _jsonNode.EnumerateObject())
             {

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>https://microsoft.github.io/kiota/</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.5</VersionPrefix>
+    <VersionPrefix>1.0.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Parsing json objects on mac catalyst without this fix, will result in null properties for resource types of microsoft graph