### PR TITLE
Adding support for deserializing arrays of type 'long'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+## [1.0.8] - 2023-07-14
+
+### Changed
+
+- Fixes deserialization of arrays with item type long
+
 ## [1.0.7] - 2023-06-28
 
 ### Changed
@@ -29,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--Fixes a bug where 'new' keyword on derived classes from IParsable is not being respected, returning null properties for json parsed nodes
+- Fixes a bug where 'new' keyword on derived classes from IParsable is not being respected, returning null properties for json parsed nodes
 
 ### Added
 

--- a/src/JsonParseNode.cs
+++ b/src/JsonParseNode.cs
@@ -223,6 +223,7 @@ namespace Microsoft.Kiota.Serialization.Json
         private static readonly Type stringType = typeof(string);
         private static readonly Type intType = typeof(int?);
         private static readonly Type floatType = typeof(float?);
+        private static readonly Type longType = typeof(long?);
         private static readonly Type doubleType = typeof(double?);
         private static readonly Type guidType = typeof(Guid?);
         private static readonly Type dateTimeOffsetType = typeof(DateTimeOffset?);
@@ -257,6 +258,8 @@ namespace Microsoft.Kiota.Serialization.Json
                         yield return (T)(object)currentParseNode.GetIntValue()!;
                     else if(genericType == floatType)
                         yield return (T)(object)currentParseNode.GetFloatValue()!;
+                    else if(genericType == longType)
+                        yield return (T)(object)currentParseNode.GetLongValue()!;
                     else if(genericType == doubleType)
                         yield return (T)(object)currentParseNode.GetDoubleValue()!;
                     else if(genericType == guidType)

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.0.7</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
For service definitions having arrays of type `long` in the response, the deserialization of that response fails

This PR fixes that issue by adding the missing lines to the `JsonParseNode.cs`

Here is an example service definition, [following the guidelines](https://swagger.io/docs/specification/data-models/data-types/#numbers) for specifying the data type `long` as `format: 'int64'`:
````yaml
definitions:
  DataItem:
    type: 'object'
    required:
      - 'items'
    properties:
      items:
        description: 'An array of int64 items'
        type: 'array'
        items:
          type: 'integer'
          format: 'int64'
        maxItems: 2147483647
        minItems: 1
````

For the above service definition, this code is generated by the Kiota generator (throwing an exception during runtime):
````c#
public IDictionary<string, Action<IParseNode>> GetFieldDeserializers()
{
    return new Dictionary<string, Action<IParseNode>> {
        {"items", n => { Items = n.GetCollectionOfPrimitiveValues<long?>()?.ToList(); } }
    };
}
````