### PR TITLE
JsonParseNode.GetCollectionOf* methods now return null when called on non array types

### DIFF
--- a/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
+++ b/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeTests.cs
@@ -138,5 +138,41 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
             // Assert
             Assert.Null(imaginaryNode);
         }
+
+        [Fact]
+        public void GetCollectionOfObjectValuesReturnsNullForNonArray()
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(TestStudentJson);
+            var jsonParseNode = new JsonParseNode(jsonDocument.RootElement);
+            // Act
+            var testEntityCollection = jsonParseNode.GetCollectionOfObjectValues<TestEntity>(x => new TestEntity());
+            // Assert
+            Assert.Null(testEntityCollection);
+        }
+
+        [Fact]
+        public void GetCollectionOfEnumValuesReturnsNullForNonArray()
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(TestStudentJson);
+            var jsonParseNode = new JsonParseNode(jsonDocument.RootElement);
+            // Act
+            var testEntityCollection = jsonParseNode.GetCollectionOfEnumValues<TestEnum>();
+            // Assert
+            Assert.Null(testEntityCollection);
+        }
+
+        [Fact]
+        public void GetCollectionOfPrimitiveValuesReturnsNullForNonArray()
+        {
+            // Arrange
+            using var jsonDocument = JsonDocument.Parse(TestStudentJson);
+            var jsonParseNode = new JsonParseNode(jsonDocument.RootElement);
+            // Act
+            var testEntityCollection = jsonParseNode.GetCollectionOfPrimitiveValues<string>();
+            // Assert
+            Assert.Null(testEntityCollection);
+        }
     }
 }

--- a/src/JsonParseNode.cs
+++ b/src/JsonParseNode.cs
@@ -181,9 +181,15 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <param name="factory">The factory to use to create the model object.</param>
         /// <returns>A collection of objects</returns>
-        public IEnumerable<T> GetCollectionOfObjectValues<T>(ParsableFactory<T> factory) where T : IParsable
+        public IEnumerable<T>? GetCollectionOfObjectValues<T>(ParsableFactory<T> factory) where T : IParsable
         {
-            if (_jsonNode.ValueKind == JsonValueKind.Array) {
+            if(_jsonNode.ValueKind != JsonValueKind.Array)
+                return null;
+
+            return ArrayToEnumerable();
+
+            IEnumerable<T> ArrayToEnumerable()
+            {
                 var enumerator = _jsonNode.EnumerateArray();
                 while(enumerator.MoveNext())
                 {
@@ -201,12 +207,18 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <returns>The collection of enum values.</returns>
 #if NET5_0_OR_GREATER
-        public IEnumerable<T?> GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>() where T : struct, Enum
+        public IEnumerable<T?>? GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>() where T : struct, Enum
 #else
-        public IEnumerable<T?> GetCollectionOfEnumValues<T>() where T : struct, Enum
+        public IEnumerable<T?>? GetCollectionOfEnumValues<T>() where T : struct, Enum
 #endif
         {
-            if (_jsonNode.ValueKind == JsonValueKind.Array) {
+            if(_jsonNode.ValueKind != JsonValueKind.Array)
+                return null;
+
+            return ArrayToEnumerable();
+
+            IEnumerable<T?> ArrayToEnumerable()
+            {
                 var enumerator = _jsonNode.EnumerateArray();
                 while(enumerator.MoveNext())
                 {
@@ -246,9 +258,15 @@ namespace Microsoft.Kiota.Serialization.Json
         /// Get the collection of primitives of type <typeparam name="T"/>from the json node
         /// </summary>
         /// <returns>A collection of objects</returns>
-        public IEnumerable<T> GetCollectionOfPrimitiveValues<T>()
+        public IEnumerable<T>? GetCollectionOfPrimitiveValues<T>()
         {
-            if (_jsonNode.ValueKind == JsonValueKind.Array) {
+            if(_jsonNode.ValueKind != JsonValueKind.Array)
+                return null;
+
+            return ArrayToEnumerable();
+
+            IEnumerable<T> ArrayToEnumerable()
+            {
                 var genericType = typeof(T);
                 foreach(var collectionValue in _jsonNode.EnumerateArray())
                 {


### PR DESCRIPTION
The Methods `GetCollectionOfPrimitiveValues`, `GetCollectionOfEnumValues` and `GetCollectionOfObjectValues` in `JsonParseNode` now return null when called on a non array type.

For this to work the changes from microsoft/kiota-abstractions-dotnet#174 are neccessary.

This change is part of the solution for the problem discussed here microsoft/kiota#3976.