### PR TITLE
Update DynamicallyAccessMembers for IParseNode Enum methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.8] - 2024-02-27
+
+- Reduced `DynamicallyAccessedMembers` scope for enum methods to prevent ILC warnings.
+
 ## [1.1.7] - 2024-02-26
 
 - Add ability to use `JsonSerializerContext` (and `JsonSerialzerOptions`) when serializing and deserializing

--- a/src/JsonParseNode.cs
+++ b/src/JsonParseNode.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <returns>An enumeration value or null</returns>
 #if NET5_0_OR_GREATER
-        public T? GetEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>() where T : struct, Enum
+        public T? GetEnumValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum
 #else
         public T? GetEnumValue<T>() where T : struct, Enum
 #endif
@@ -249,7 +249,7 @@ namespace Microsoft.Kiota.Serialization.Json
         /// </summary>
         /// <returns>The collection of enum values.</returns>
 #if NET5_0_OR_GREATER
-        public IEnumerable<T?> GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]T>() where T : struct, Enum
+        public IEnumerable<T?> GetCollectionOfEnumValues<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>() where T : struct, Enum
 #else
         public IEnumerable<T?> GetCollectionOfEnumValues<T>() where T : struct, Enum
 #endif
@@ -440,12 +440,12 @@ namespace Microsoft.Kiota.Serialization.Json
         }
         
 #if NET5_0_OR_GREATER
-        private static string ToEnumRawName<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string value) where T : struct, Enum
+        private static string ToEnumRawName<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(string value) where T : struct, Enum
 #else
         private static string ToEnumRawName<T>(string value) where T : struct, Enum
 #endif
         {
-            if (typeof(T).GetMembers().FirstOrDefault(member =>
+            if (typeof(T).GetFields().FirstOrDefault(member =>
                    member.GetCustomAttribute<EnumMemberAttribute>() is { } attr &&
                    value.Equals(attr.Value, StringComparison.Ordinal))?.Name is { } strValue)
                 return strValue;

--- a/src/JsonSerializationWriter.cs
+++ b/src/JsonSerializationWriter.cs
@@ -421,6 +421,7 @@ namespace Microsoft.Kiota.Serialization.Json
                     WriteAnyValue(oProp.Name, oProp.GetValue(value));
             writer.WriteEndObject();
         }
+
         private void WriteAnyValue<T>(string? key, T value)
         {
             switch(value)

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.1.7</VersionPrefix>
+    <VersionPrefix>1.1.8</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -43,7 +43,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.10" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.7.11" />
     <PackageReference Include="System.Text.Json" Version="[6.0,9.0)" />
   </ItemGroup>
 


### PR DESCRIPTION
Updates DynamicallyAccessMembers for IParseNode Enum methods to align with changes from https://github.com/microsoft/kiota-abstractions-dotnet/pull/202

Due to how AdditionalData is stored and serialized, this assembly isn't quite fully trim-safe yet, as [`WriteNonParsableObjectValue<T>(string? key, T value)`](https://github.com/microsoft/kiota-serialization-json-dotnet/blob/9941827b1be3fbf291d4e31a68faf24166ec31e1/src/JsonSerializationWriter.cs#L412) is always used for a `T` of `object`.