### PR TITLE
Fixes azure pipeline

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -25,239 +25,239 @@ resources:
     ref: refs/tags/release
 
 extends:
-template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
-parameters:
-  pool:
-    name: Azure-Pipelines-1ESPT-ExDShared
-    vmImage: windows-latest
-  stages: 
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      vmImage: windows-latest
+    stages: 
 
-    - stage: build
-      jobs:
-        - job: build
-          steps:
+      - stage: build
+        jobs:
+          - job: build
+            steps:
 
-          - task: UseDotNet@2
-            displayName: 'Use .NET 6' # needed for ESRP signing
-            inputs:
-              version: 6.x
+            - task: UseDotNet@2
+              displayName: 'Use .NET 6' # needed for ESRP signing
+              inputs:
+                version: 6.x
 
-          - task: UseDotNet@2
-            displayName: 'Use .NET 8'
-            inputs:
-              version: 8.x
+            - task: UseDotNet@2
+              displayName: 'Use .NET 8'
+              inputs:
+                version: 8.x
 
-          # Install the nuget tool.
-          - task: NuGetToolInstaller@1
-            displayName: 'Install Nuget dependency manager'
-            inputs:
-              versionSpec: '>=5.2.0'
-              checkLatest: true
+            # Install the nuget tool.
+            - task: NuGetToolInstaller@1
+              displayName: 'Install Nuget dependency manager'
+              inputs:
+                versionSpec: '>=5.2.0'
+                checkLatest: true
 
-          - task: PowerShell@2
-            displayName: 'Enable signing'
-            inputs:
-              targetType: filePath
-              filePath: 'scripts\EnableSigning.ps1'
-              arguments: '-projectPath "$(Build.SourcesDirectory)/src/Microsoft.Kiota.Serialization.Json.csproj"'
-              pwsh: true
-            enabled: true
+            - task: PowerShell@2
+              displayName: 'Enable signing'
+              inputs:
+                targetType: filePath
+                filePath: 'scripts\EnableSigning.ps1'
+                arguments: '-projectPath "$(Build.SourcesDirectory)/src/Microsoft.Kiota.Serialization.Json.csproj"'
+                pwsh: true
+              enabled: true
 
-          # Build the Product project
-          - task: DotNetCoreCLI@2
-            displayName: 'Build Microsoft.Kiota.Serialization.Json'
-            inputs:
-              projects: '$(Build.SourcesDirectory)\Microsoft.Kiota.Serialization.Json.sln'
-              arguments: '--configuration $(BuildConfiguration) --no-incremental'
+            # Build the Product project
+            - task: DotNetCoreCLI@2
+              displayName: 'Build Microsoft.Kiota.Serialization.Json'
+              inputs:
+                projects: '$(Build.SourcesDirectory)\Microsoft.Kiota.Serialization.Json.sln'
+                arguments: '--configuration $(BuildConfiguration) --no-incremental'
 
-          # Run the Unit test
-          - task: DotNetCoreCLI@2
-            displayName: 'Test Microsoft.Kiota.Serialization.Json'
-            inputs:
-              command: test
-              projects: '$(Build.SourcesDirectory)\Microsoft.Kiota.Serialization.Json.sln'
-              arguments: '--configuration $(BuildConfiguration) --no-build -f net8.0'
+            # Run the Unit test
+            - task: DotNetCoreCLI@2
+              displayName: 'Test Microsoft.Kiota.Serialization.Json'
+              inputs:
+                command: test
+                projects: '$(Build.SourcesDirectory)\Microsoft.Kiota.Serialization.Json.sln'
+                arguments: '--configuration $(BuildConfiguration) --no-build -f net8.0'
 
-          - task: EsrpCodeSigning@2
-            displayName: 'ESRP DLL Strong Name'
-            inputs:
-              ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-              FolderPath: $(ProductBinPath)
-              Pattern: '**\*Microsoft.Kiota.Serialization.Json.dll'
-              UseMinimatch: true
-              signConfigType: inlineSignParams
-              inlineOperation: |
-                [
-                    {
-                        "keyCode": "CP-233863-SN",
-                        "operationSetCode": "StrongNameSign",
-                        "parameters": [],
-                        "toolName": "sign",
-                        "toolVersion": "1.0"
-                    },
-                    {
-                        "keyCode": "CP-233863-SN",
-                        "operationSetCode": "StrongNameVerify",
-                        "parameters": [],
-                        "toolName": "sign",
-                        "toolVersion": "1.0"
-                    }
-                ]
-              SessionTimeout: 20
+            - task: EsrpCodeSigning@2
+              displayName: 'ESRP DLL Strong Name'
+              inputs:
+                ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+                FolderPath: $(ProductBinPath)
+                Pattern: '**\*Microsoft.Kiota.Serialization.Json.dll'
+                UseMinimatch: true
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                  [
+                      {
+                          "keyCode": "CP-233863-SN",
+                          "operationSetCode": "StrongNameSign",
+                          "parameters": [],
+                          "toolName": "sign",
+                          "toolVersion": "1.0"
+                      },
+                      {
+                          "keyCode": "CP-233863-SN",
+                          "operationSetCode": "StrongNameVerify",
+                          "parameters": [],
+                          "toolName": "sign",
+                          "toolVersion": "1.0"
+                      }
+                  ]
+                SessionTimeout: 20
 
-          - task: EsrpCodeSigning@2
-            displayName: 'ESRP DLL CodeSigning'
-            inputs:
-              ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-              FolderPath: src
-              Pattern: '**\*Microsoft.Kiota.Serialization.Json.dll'
-              UseMinimatch: true
-              signConfigType: inlineSignParams
-              inlineOperation: |
-                [
-                    {
-                        "keyCode": "CP-230012",
-                        "operationSetCode": "SigntoolSign",
-                        "parameters": [
-                        {
-                            "parameterName": "OpusName",
-                            "parameterValue": "Microsoft"
-                        },
-                        {
-                            "parameterName": "OpusInfo",
-                            "parameterValue": "http://www.microsoft.com"
-                        },
-                        {
-                            "parameterName": "FileDigest",
-                            "parameterValue": "/fd \"SHA256\""
-                        },
-                        {
-                            "parameterName": "PageHash",
-                            "parameterValue": "/NPH"
-                        },
-                        {
-                            "parameterName": "TimeStamp",
-                            "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                        }
-                        ],
-                        "toolName": "sign",
-                        "toolVersion": "1.0"
-                    },
-                    {
-                        "keyCode": "CP-230012",
-                        "operationSetCode": "SigntoolVerify",
-                        "parameters": [ ],
-                        "toolName": "sign",
-                        "toolVersion": "1.0"
-                    }
-                ]
-              SessionTimeout: 20
+            - task: EsrpCodeSigning@2
+              displayName: 'ESRP DLL CodeSigning'
+              inputs:
+                ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+                FolderPath: src
+                Pattern: '**\*Microsoft.Kiota.Serialization.Json.dll'
+                UseMinimatch: true
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                  [
+                      {
+                          "keyCode": "CP-230012",
+                          "operationSetCode": "SigntoolSign",
+                          "parameters": [
+                          {
+                              "parameterName": "OpusName",
+                              "parameterValue": "Microsoft"
+                          },
+                          {
+                              "parameterName": "OpusInfo",
+                              "parameterValue": "http://www.microsoft.com"
+                          },
+                          {
+                              "parameterName": "FileDigest",
+                              "parameterValue": "/fd \"SHA256\""
+                          },
+                          {
+                              "parameterName": "PageHash",
+                              "parameterValue": "/NPH"
+                          },
+                          {
+                              "parameterName": "TimeStamp",
+                              "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                          }
+                          ],
+                          "toolName": "sign",
+                          "toolVersion": "1.0"
+                      },
+                      {
+                          "keyCode": "CP-230012",
+                          "operationSetCode": "SigntoolVerify",
+                          "parameters": [ ],
+                          "toolName": "sign",
+                          "toolVersion": "1.0"
+                      }
+                  ]
+                SessionTimeout: 20
 
-          # arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
-          - pwsh: dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Kiota.Serialization.Json.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
-            env:
-              BUILD_CONFIGURATION: $(BuildConfiguration)
-            displayName: Dotnet pack
+            # arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
+            - pwsh: dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Kiota.Serialization.Json.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+              env:
+                BUILD_CONFIGURATION: $(BuildConfiguration)
+              displayName: Dotnet pack
 
-          - task: PowerShell@2
-            displayName: 'Validate project version has been incremented'
-            condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-            inputs:
-              targetType: 'filePath'
-              filePath: $(System.DefaultWorkingDirectory)\scripts\ValidateProjectVersionUpdated.ps1
-              arguments: '-projectPath "$(Build.SourcesDirectory)/src/Microsoft.Kiota.Serialization.Json.csproj" -packageName "Microsoft.Kiota.Serialization.Json"'
-              pwsh: true
+            - task: PowerShell@2
+              displayName: 'Validate project version has been incremented'
+              condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+              inputs:
+                targetType: 'filePath'
+                filePath: $(System.DefaultWorkingDirectory)\scripts\ValidateProjectVersionUpdated.ps1
+                arguments: '-projectPath "$(Build.SourcesDirectory)/src/Microsoft.Kiota.Serialization.Json.csproj" -packageName "Microsoft.Kiota.Serialization.Json"'
+                pwsh: true
 
-          - task: EsrpCodeSigning@2
-            displayName: 'ESRP CodeSigning Nuget Packages'
-            inputs:
-              ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-              FolderPath: '$(Build.ArtifactStagingDirectory)'
-              Pattern: '*.nupkg'
-              UseMinimatch: true
-              signConfigType: inlineSignParams
-              inlineOperation: |
-                [
-                    {
-                        "keyCode": "CP-401405",
-                        "operationSetCode": "NuGetSign",
-                        "parameters": [ ],
-                        "toolName": "sign",
-                        "toolVersion": "1.0"
-                    },
-                    {
-                        "keyCode": "CP-401405",
-                        "operationSetCode": "NuGetVerify",
-                        "parameters": [ ],
-                        "toolName": "sign",
-                        "toolVersion": "1.0"
-                    }
-                ]
-              SessionTimeout: 20
+            - task: EsrpCodeSigning@2
+              displayName: 'ESRP CodeSigning Nuget Packages'
+              inputs:
+                ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+                FolderPath: '$(Build.ArtifactStagingDirectory)'
+                Pattern: '*.nupkg'
+                UseMinimatch: true
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                  [
+                      {
+                          "keyCode": "CP-401405",
+                          "operationSetCode": "NuGetSign",
+                          "parameters": [ ],
+                          "toolName": "sign",
+                          "toolVersion": "1.0"
+                      },
+                      {
+                          "keyCode": "CP-401405",
+                          "operationSetCode": "NuGetVerify",
+                          "parameters": [ ],
+                          "toolName": "sign",
+                          "toolVersion": "1.0"
+                      }
+                  ]
+                SessionTimeout: 20
 
-          - task: CopyFiles@2
-            displayName: 'Copy release scripts to artifact staging directory'
-            condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-            inputs:
-              SourceFolder: '$(Build.SourcesDirectory)'
-              Contents: 'scripts\**'
-              TargetFolder: '$(Build.ArtifactStagingDirectory)'
+            - task: CopyFiles@2
+              displayName: 'Copy release scripts to artifact staging directory'
+              condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+              inputs:
+                SourceFolder: '$(Build.SourcesDirectory)'
+                Contents: 'scripts\**'
+                TargetFolder: '$(Build.ArtifactStagingDirectory)'
 
-          - task: 1ES.PublishPipelineArtifact@1
-            displayName: 'Upload Artifact: Nugets'
-            inputs:
-              artifactName: Nugets
-              targetPath: $(Build.ArtifactStagingDirectory)
+            - task: 1ES.PublishPipelineArtifact@1
+              displayName: 'Upload Artifact: Nugets'
+              inputs:
+                artifactName: Nugets
+                targetPath: $(Build.ArtifactStagingDirectory)
 
-    - stage: deploy
-      condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
-      dependsOn: build
-      jobs:
-        - deployment: deploy_dotnet_serialization_json
-          dependsOn: []
-          environment: nuget-org
-          strategy:
-            runOnce:
-              deploy:
-                pool:
-                  vmImage: ubuntu-latest
-                steps:
-                # Install the nuget tool.
-                - task: NuGetToolInstaller@0
-                  displayName: 'Use NuGet >=5.2.0'
-                  inputs:
-                    versionSpec: '>=5.2.0'
-                    checkLatest: true
-                - task: DownloadPipelineArtifact@2
-                  displayName: Download nupkg from artifacts
-                  inputs:
-                    artifact: Nugets
-                    source: current
-                - task: PowerShell@2
-                  displayName: 'Extract release information to pipeline'
-                  inputs:
-                    targetType: 'filePath'
-                    filePath: $(Pipeline.Workspace)\scripts\GetNugetPackageVersion.ps1
-                    pwsh: true
-                    arguments: '-packageDirPath "$(Pipeline.Workspace)/"'
-                - task: NuGetCommand@2
-                  displayName: 'NuGet push'
-                  inputs:
-                    command: push
-                    packagesToPush: '$(Pipeline.Workspace)/Microsoft.Kiota.Serialization.Json.*.nupkg'
-                    packageParentPath: '$(Pipeline.Workspace)'
-                    nuGetFeedType: external
-                    publishFeedCredentials: 'Kiota Nuget Connection'
-                - task: GitHubRelease@1
-                  displayName: 'GitHub release (create)'
-                  inputs:
-                    gitHubConnection: 'Kiota_Release'
-                    target: $(Build.SourceVersion)
-                    tagSource: userSpecifiedTag
-                    tag: 'v$(VERSION_STRING)'
-                    title: '$(VERSION_STRING)'
-                    releaseNotesSource: inline
-                    assets: '!**/**'
-                    changeLogType: issueBased
-                    isPreRelease : '$(IS_PRE_RELEASE)'
-                    addChangeLog : true
+      - stage: deploy
+        condition: and(contains(variables['build.sourceBranch'], 'refs/heads/main'), succeeded())
+        dependsOn: build
+        jobs:
+          - deployment: deploy_dotnet_serialization_json
+            dependsOn: []
+            environment: nuget-org
+            strategy:
+              runOnce:
+                deploy:
+                  pool:
+                    vmImage: ubuntu-latest
+                  steps:
+                  # Install the nuget tool.
+                  - task: NuGetToolInstaller@0
+                    displayName: 'Use NuGet >=5.2.0'
+                    inputs:
+                      versionSpec: '>=5.2.0'
+                      checkLatest: true
+                  - task: DownloadPipelineArtifact@2
+                    displayName: Download nupkg from artifacts
+                    inputs:
+                      artifact: Nugets
+                      source: current
+                  - task: PowerShell@2
+                    displayName: 'Extract release information to pipeline'
+                    inputs:
+                      targetType: 'filePath'
+                      filePath: $(Pipeline.Workspace)\scripts\GetNugetPackageVersion.ps1
+                      pwsh: true
+                      arguments: '-packageDirPath "$(Pipeline.Workspace)/"'
+                  - task: NuGetCommand@2
+                    displayName: 'NuGet push'
+                    inputs:
+                      command: push
+                      packagesToPush: '$(Pipeline.Workspace)/Microsoft.Kiota.Serialization.Json.*.nupkg'
+                      packageParentPath: '$(Pipeline.Workspace)'
+                      nuGetFeedType: external
+                      publishFeedCredentials: 'Kiota Nuget Connection'
+                  - task: GitHubRelease@1
+                    displayName: 'GitHub release (create)'
+                    inputs:
+                      gitHubConnection: 'Kiota_Release'
+                      target: $(Build.SourceVersion)
+                      tagSource: userSpecifiedTag
+                      tag: 'v$(VERSION_STRING)'
+                      title: '$(VERSION_STRING)'
+                      releaseNotesSource: inline
+                      assets: '!**/**'
+                      changeLogType: issueBased
+                      isPreRelease : '$(IS_PRE_RELEASE)'
+                      addChangeLog : true

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -240,8 +240,8 @@ extends:
                       filePath: $(Pipeline.Workspace)\scripts\GetNugetPackageVersion.ps1
                       pwsh: true
                       arguments: '-packageDirPath "$(Pipeline.Workspace)/"'
-                  - task: NuGetCommand@2
-                    displayName: 'NuGet push'
+                  - task: 1ES.PublishNuget@1
+                    displayName: 'Push release to NuGet.org'
                     inputs:
                       command: push
                       packagesToPush: '$(Pipeline.Workspace)/Microsoft.Kiota.Serialization.Json.*.nupkg'


### PR DESCRIPTION
Follow up to https://github.com/microsoft/kiota-serialization-json-dotnet/pull/192 to unblock release of #198 

In summary changes include
- Fixes invalid yaml syntax due to indentation level
- Changes nuget push command to use the `1ES.PublishNuget@1` task
