### PR TITLE
Remove LINQ usage from Enum conversion from/to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2024-05-13
+## [1.3.1] - 2024-05-20
 
 ### Changed
 
 - Updated serialization and deserialization of enums to remove LINQ to resolve NativeAOT compatibility issue
+
+## [1.3.0] - 2024-05-13
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - 2024-05-13
 
+### Changed
+
+- Updated serialization and deserialization of enums to remove LINQ to resolve NativeAOT compatibility issue
+
 ### Added
 
 - Implements IAsyncParseNodeFactory interface which adds async support 

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>1.3.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This prevents unintended and unbound generic specialization expansion in the NativeAOT compiler.

Fixes #226 