### PR TITLE
bugfix: version range for abstractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2024-05-23
+
+### Changed
+
+- Fixed an issue where fixed versions of abstractions would result in restore failures. [microsoft/kiota-http-dotnet#256](https://github.com/microsoft/kiota-http-dotnet/issues/258)
+
 ## [1.3.1] - 2024-05-20
 
 ### Changed

--- a/Microsoft.Kiota.Serialization.Json.Tests/IntersectionWrapperParseTests.cs
+++ b/Microsoft.Kiota.Serialization.Json.Tests/IntersectionWrapperParseTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Kiota.Serialization.Json.Tests.Mocks;
 using Xunit;
 
@@ -11,11 +12,11 @@ public class IntersectionWrapperParseTests {
     private readonly JsonSerializationWriterFactory _serializationWriterFactory = new();
     private const string contentType = "application/json";
     [Fact]
-    public void ParsesIntersectionTypeComplexProperty1()
+    public async Task ParsesIntersectionTypeComplexProperty1()
     {
         // Given
         using var payload = new MemoryStream(Encoding.UTF8.GetBytes("{\"displayName\":\"McGill\",\"officeLocation\":\"Montreal\", \"id\": \"opaque\"}"));
-        var parseNode = _parseNodeFactory.GetRootParseNode(contentType, payload);
+        var parseNode = await _parseNodeFactory.GetRootParseNodeAsync(contentType, payload);
     
         // When
         var result = parseNode.GetObjectValue<IntersectionTypeMock>(IntersectionTypeMock.CreateFromDiscriminator);
@@ -30,11 +31,11 @@ public class IntersectionWrapperParseTests {
         Assert.Equal("McGill", result.ComposedType2.DisplayName);
     }
     [Fact]
-    public void ParsesIntersectionTypeComplexProperty2()
+    public async Task ParsesIntersectionTypeComplexProperty2()
     {
         // Given
         using var payload = new MemoryStream(Encoding.UTF8.GetBytes("{\"displayName\":\"McGill\",\"officeLocation\":\"Montreal\", \"id\": 10}"));
-        var parseNode = _parseNodeFactory.GetRootParseNode(contentType, payload);
+        var parseNode = await _parseNodeFactory.GetRootParseNodeAsync(contentType, payload);
     
         // When
         var result = parseNode.GetObjectValue<IntersectionTypeMock>(IntersectionTypeMock.CreateFromDiscriminator);
@@ -50,11 +51,11 @@ public class IntersectionWrapperParseTests {
         Assert.Equal("McGill", result.ComposedType2.DisplayName);
     }
     [Fact]
-    public void ParsesIntersectionTypeComplexProperty3()
+    public async Task ParsesIntersectionTypeComplexProperty3()
     {
         // Given
         using var payload = new MemoryStream(Encoding.UTF8.GetBytes("[{\"@odata.type\":\"#microsoft.graph.TestEntity\",\"officeLocation\":\"Ottawa\", \"id\": \"11\"}, {\"@odata.type\":\"#microsoft.graph.TestEntity\",\"officeLocation\":\"Montreal\", \"id\": \"10\"}]"));
-        var parseNode = _parseNodeFactory.GetRootParseNode(contentType, payload);
+        var parseNode = await _parseNodeFactory.GetRootParseNodeAsync(contentType, payload);
     
         // When
         var result = parseNode.GetObjectValue<IntersectionTypeMock>(IntersectionTypeMock.CreateFromDiscriminator);
@@ -69,11 +70,11 @@ public class IntersectionWrapperParseTests {
         Assert.Equal("Ottawa", result.ComposedType3.First().OfficeLocation);
     }
     [Fact]
-    public void ParsesIntersectionTypeStringValue()
+    public async Task ParsesIntersectionTypeStringValue()
     {
         // Given
         using var payload = new MemoryStream(Encoding.UTF8.GetBytes("\"officeLocation\""));
-        var parseNode = _parseNodeFactory.GetRootParseNode(contentType, payload);
+        var parseNode = await _parseNodeFactory.GetRootParseNodeAsync(contentType, payload);
     
         // When
         var result = parseNode.GetObjectValue<IntersectionTypeMock>(IntersectionTypeMock.CreateFromDiscriminator);

--- a/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeFactoryTests.cs
+++ b/Microsoft.Kiota.Serialization.Json.Tests/JsonParseNodeFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Kiota.Serialization.Json.Tests
@@ -16,10 +17,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         }
 
         [Fact]
-        public void GetsWriterForJsonContentType()
+        public async Task GetsWriterForJsonContentType()
         {
             using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
-            var jsonWriter = _jsonParseNodeFactory.GetRootParseNode(_jsonParseNodeFactory.ValidContentType,jsonStream);
+            var jsonWriter = await _jsonParseNodeFactory.GetRootParseNodeAsync(_jsonParseNodeFactory.ValidContentType,jsonStream);
 
             // Assert
             Assert.NotNull(jsonWriter);
@@ -27,11 +28,11 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         }
 
         [Fact]
-        public void ThrowsArgumentOutOfRangeExceptionForInvalidContentType()
+        public async Task ThrowsArgumentOutOfRangeExceptionForInvalidContentType()
         {
             var streamContentType = "application/octet-stream";
             using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
-            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => _jsonParseNodeFactory.GetRootParseNode(streamContentType,jsonStream));
+            var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await _jsonParseNodeFactory.GetRootParseNodeAsync(streamContentType,jsonStream));
 
             // Assert
             Assert.NotNull(exception);
@@ -41,10 +42,10 @@ namespace Microsoft.Kiota.Serialization.Json.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void ThrowsArgumentNullExceptionForNoContentType(string contentType)
+        public async Task ThrowsArgumentNullExceptionForNoContentType(string contentType)
         {
             using var jsonStream = new MemoryStream(Encoding.UTF8.GetBytes(TestJsonString));
-            var exception = Assert.Throws<ArgumentNullException>(() => _jsonParseNodeFactory.GetRootParseNode(contentType,jsonStream));
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(async () => await _jsonParseNodeFactory.GetRootParseNodeAsync(contentType,jsonStream));
 
             // Assert
             Assert.NotNull(exception);

--- a/Microsoft.Kiota.Serialization.Json.Tests/UnionWrapperParseTests.cs
+++ b/Microsoft.Kiota.Serialization.Json.Tests/UnionWrapperParseTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.Kiota.Serialization.Json.Tests.Mocks;
 using Xunit;
 
@@ -11,11 +12,11 @@ public class UnionWrapperParseTests {
     private readonly JsonSerializationWriterFactory _serializationWriterFactory = new();
     private const string contentType = "application/json";
     [Fact]
-    public void ParsesUnionTypeComplexProperty1()
+    public async Task ParsesUnionTypeComplexProperty1()
     {
         // Given
         using var payload = new MemoryStream(Encoding.UTF8.GetBytes("{\"@odata.type\":\"#microsoft.graph.testEntity\",\"officeLocation\":\"Montreal\", \"id\": \"opaque\"}"));
-        var parseNode = _parseNodeFactory.GetRootParseNode(contentType, payload);
+        var parseNode = await _parseNodeFactory.GetRootParseNodeAsync(contentType, payload);
     
         // When
         var result = parseNode.GetObjectValue<UnionTypeMock>(UnionTypeMock.CreateFromDiscriminator);
@@ -29,11 +30,11 @@ public class UnionWrapperParseTests {
         Assert.Equal("opaque", result.ComposedType1.Id);
     }
     [Fact]
-    public void ParsesUnionTypeComplexProperty2()
+    public async Task ParsesUnionTypeComplexProperty2()
     {
         // Given
         using var payload = new MemoryStream(Encoding.UTF8.GetBytes("{\"@odata.type\":\"#microsoft.graph.secondTestEntity\",\"officeLocation\":\"Montreal\", \"id\": 10}"));
-        var parseNode = _parseNodeFactory.GetRootParseNode(contentType, payload);
+        var parseNode = await _parseNodeFactory.GetRootParseNodeAsync(contentType, payload);
     
         // When
         var result = parseNode.GetObjectValue<UnionTypeMock>(UnionTypeMock.CreateFromDiscriminator);
@@ -47,11 +48,11 @@ public class UnionWrapperParseTests {
         Assert.Equal(10, result.ComposedType2.Id);
     }
     [Fact]
-    public void ParsesUnionTypeComplexProperty3()
+    public async Task ParsesUnionTypeComplexProperty3()
     {
         // Given
         using var payload = new MemoryStream(Encoding.UTF8.GetBytes("[{\"@odata.type\":\"#microsoft.graph.TestEntity\",\"officeLocation\":\"Ottawa\", \"id\": \"11\"}, {\"@odata.type\":\"#microsoft.graph.TestEntity\",\"officeLocation\":\"Montreal\", \"id\": \"10\"}]"));
-        var parseNode = _parseNodeFactory.GetRootParseNode(contentType, payload);
+        var parseNode = await _parseNodeFactory.GetRootParseNodeAsync(contentType, payload);
     
         // When
         var result = parseNode.GetObjectValue<UnionTypeMock>(UnionTypeMock.CreateFromDiscriminator);
@@ -63,14 +64,14 @@ public class UnionWrapperParseTests {
         Assert.Null(result.ComposedType1);
         Assert.Null(result.StringValue);
         Assert.Equal(2, result.ComposedType3.Count);
-        Assert.Equal("11", result.ComposedType3.First().Id);
+        Assert.Equal("11", result.ComposedType3[0].Id);
     }
     [Fact]
-    public void ParsesUnionTypeStringValue()
+    public async Task ParsesUnionTypeStringValue()
     {
         // Given
         using var payload = new MemoryStream(Encoding.UTF8.GetBytes("\"officeLocation\""));
-        var parseNode = _parseNodeFactory.GetRootParseNode(contentType, payload);
+        var parseNode = await _parseNodeFactory.GetRootParseNodeAsync(contentType, payload);
     
         // When
         var result = parseNode.GetObjectValue<UnionTypeMock>(UnionTypeMock.CreateFromDiscriminator);

--- a/src/Microsoft.Kiota.Serialization.Json.csproj
+++ b/src/Microsoft.Kiota.Serialization.Json.csproj
@@ -15,7 +15,7 @@
     <PackageProjectUrl>https://aka.ms/kiota/docs</PackageProjectUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>
-    <VersionPrefix>1.3.1</VersionPrefix>
+    <VersionPrefix>1.3.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="1.9.1" />
+    <PackageReference Include="Microsoft.Kiota.Abstractions" Version="[1.9.1, 2.0.0)" />
   </ItemGroup>
 
   <!-- NET 5 target to be removed on next major version-->


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota-http-dotnet/issues/258

Also updates tests to use non-obsolete interfaced.